### PR TITLE
Fix compilation errors for Ceres Solver v2.2+

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ catkin_make
 source devel/setup.bash
 ```
 
-Note: You need to put livox_ros_driver2 and livox_camera_lidar_calibration_d2 under the same src. 
-
+Note: You need to put livox_ros_driver2 and livox_camera_lidar_calibration_d2 under the same src. If you are still using livox_ros_driver, you should modify the `msg_type` to `livox_ros_driver/CustomMsg` in `config/params.yaml`.
 ## 3.Calibrating camera and lidar external parameters
 
 ## 4.Verify and use external parameters

--- a/config/params.yaml
+++ b/config/params.yaml
@@ -1,0 +1,1 @@
+msg_type: "livox_ros_driver2/CustomMsg"

--- a/launch/cameraCalib.launch
+++ b/launch/cameraCalib.launch
@@ -3,13 +3,12 @@
     <param name="camera_in_path"        value="$(find camera_lidar_calibration)/../../data/camera/in.txt" />  <!-- the file to contain all the photos -->
     <param name="camera_folder_path"    value="$(find camera_lidar_calibration)/../../data/camera/photos/" />  <!-- the file to contain all the photos -->
     <param name="result_path"           value="$(find camera_lidar_calibration)/../../data/camera/result.txt" />  <!-- the file to save the intrinsic data -->
-    
+
     <param name="row_number"            type="int" value="8" />  <!-- the number of block on the row -->
     <param name="col_number"            type="int" value="6" />  <!-- the number of block on the column -->
     <param name="width"                 type="int" value="38" />  <!-- the width of each block on the chessboard(mm) -->
     <param name="height"                type="int" value="38" />  <!-- the height of each block on the chessboard(mm)-->
-    
+
     <node pkg="camera_lidar_calibration" name="cameraCalib" type="cameraCalib" output="screen"></node>
 
 </launch>
-

--- a/launch/colorLidar.launch
+++ b/launch/colorLidar.launch
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  
+    <rosparam command="load" file="$(find camera_lidar_calibration)/config/params.yaml" />
+
     <param name="intrinsic_path"        value="$(find camera_lidar_calibration)/../../data/parameters/intrinsic.txt" />  <!-- intrinsic file -->
     <param name="extrinsic_path"        value="$(find camera_lidar_calibration)/../../data/parameters/extrinsic.txt" />  <!-- extrinsic file -->
-  
+
     <param name="input_bag_path"        value="$(find camera_lidar_calibration)/../../data/lidar/0.bag" />  <!-- rosbag to give the lidar info -->
     <param name="input_photo_path"      value="$(find camera_lidar_calibration)/../../data/photo/0.bmp" />  <!-- photo to get RGB info -->
 
     <param name="threshold_lidar"       type="int" value="80" />  <!-- the limit of messages to transfer to the pcd file, 80 means maximum 80 messages of lidar -->
-    
+
   <node pkg="camera_lidar_calibration" name="colorLidar" type="colorLidar" output="screen"></node>
-  
+
   <node name="rviz" pkg="rviz" type="rviz" respawn="true" args="-d $(find camera_lidar_calibration)/launch/config.rviz"/>
 
 </launch>
-

--- a/launch/cornerPhoto.launch
+++ b/launch/cornerPhoto.launch
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  
+
     <param name="intrinsic_path"           value="$(find camera_lidar_calibration)/../../data/parameters/intrinsic.txt" />  <!-- intrinsic file -->
     <param name="input_photo_folder_path"  value="$(find camera_lidar_calibration)/../../data/photo" />   <!-- photo's folder to find the corners -->
     <param name="ouput_path"               value="$(find camera_lidar_calibration)/../../data/corner_photo.txt" />  <!-- file to save the photo corners -->
-    
+
     <node pkg="camera_lidar_calibration" name="cornerPhoto" type="cornerPhoto" output="screen"></node>
 
 </launch>
-

--- a/launch/getExt1.launch
+++ b/launch/getExt1.launch
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  
+
     <rosparam param="init_value">  [0.0, -1.0, 0.0, 0.0,
                                     0.0, 0.0, -1.0, 0.0,
                                     1.0, 0.0, 0.0,  0.0] </rosparam>  <!-- init value of roatation matrix(3*3 on the left) and the translation(3*1 vector on the right) -->
@@ -14,4 +14,3 @@
     <node pkg="camera_lidar_calibration" name="getExt1" type="getExt1" output="screen"></node>
 
 </launch>
-

--- a/launch/getExt2.launch
+++ b/launch/getExt2.launch
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  
+
     <rosparam param="init_value">  [0.0, -1.0, 0.0, 0.0,
                                     0.0, 0.0, -1.0, 0.0,
                                     1.0, 0.0, 0.0,  0.0] </rosparam>  <!-- init value of roatation matrix(3*3 on the left) and the translation(3*1 vector on the right) -->
-  
+
     <param name="intrinsic_path"    value="$(find camera_lidar_calibration)/../../data/parameters/intrinsic.txt" />  <!-- intrinsic file -->
     <param name="extrinsic_path"    value="$(find camera_lidar_calibration)/../../data/parameters/extrinsic.txt" />  <!-- extrinsic file -->
     <param name="input_lidar_path"  value="$(find camera_lidar_calibration)/../../data/corner_lidar.txt" />  <!-- get the lidar corner data -->
@@ -14,4 +14,3 @@
     <node pkg="camera_lidar_calibration" name="getExt2" type="getExt2" output="screen"></node>
 
 </launch>
-

--- a/launch/pcdTransfer.launch
+++ b/launch/pcdTransfer.launch
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+    <rosparam command="load" file="$(find camera_lidar_calibration)/config/params.yaml" />
+
     <param name="input_bag_path"        value="$(find camera_lidar_calibration)/../../data/lidar/" />  <!-- rosbag folder -->
     <param name="output_pcd_path"       value="$(find camera_lidar_calibration)/../../data/pcdFiles/" />  <!-- path to save new pcd files -->
-    
+
     <param name="threshold_lidar"       type="int" value="80" />  <!-- the limit of messages to transfer to the pcd file, 80 means maximum 80 messages of lidar -->
     <param name="data_num"              type="int" value="10" />  <!-- the number of the rosbag -->
-  
+
     <node pkg="camera_lidar_calibration" name="pcdTransfer" type="pcdTransfer" output="screen"></node>
 
 </launch>
-

--- a/launch/projectCloud.launch
+++ b/launch/projectCloud.launch
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
-  
+    <rosparam command="load" file="$(find camera_lidar_calibration)/config/params.yaml" />
+
     <param name="intrinsic_path"        value="$(find camera_lidar_calibration)/../../data/parameters/intrinsic.txt" />  <!-- intrinsic file -->
     <param name="extrinsic_path"        value="$(find camera_lidar_calibration)/../../data/parameters/extrinsic.txt" />  <!-- extrinsic file -->
-    
+
     <param name="input_bag_path"        value="$(find camera_lidar_calibration)/../../data/lidar/0.bag" />  <!-- rosbag file -->
     <param name="input_photo_path"      value="$(find camera_lidar_calibration)/../../data/photo/0.bmp" />  <!-- photo file -->
     <param name="output_path"           value="$(find camera_lidar_calibration)/../../data/projection/new.bmp" />  <!-- path to save new photo file -->
@@ -13,4 +14,3 @@
     <node pkg="camera_lidar_calibration" name="projectCloud" type="projectCloud" output="screen"></node>
 
 </launch>
-

--- a/src/cam_lid_external1.cpp
+++ b/src/cam_lid_external1.cpp
@@ -1,6 +1,5 @@
 #include <ros/ros.h>
 #include <iostream>
-#include <ceres/ceres.h>
 #include <Eigen/Core>
 #include <fstream>
 #include <pcl/point_cloud.h>
@@ -12,6 +11,7 @@
 
 #include "common.h"
 #include "result_verify.h"
+#include "type.h"
 
 using namespace std;
 
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     Eigen::Map<Eigen::Quaterniond> m_q = Eigen::Map<Eigen::Quaterniond>(ext);
     Eigen::Map<Eigen::Vector3d> m_t = Eigen::Map<Eigen::Vector3d>(ext + 4);
 
-    ceres::Manifold * q_parameterization = new ceres::EigenQuaternionManifold();
+    ParameterizationPtr q_parameterization = new ParameterizationType();
     ceres::Problem problem;
 
     problem.AddParameterBlock(ext, 4, q_parameterization);

--- a/src/cam_lid_external1.cpp
+++ b/src/cam_lid_external1.cpp
@@ -120,7 +120,7 @@ int main(int argc, char **argv) {
     Eigen::Map<Eigen::Quaterniond> m_q = Eigen::Map<Eigen::Quaterniond>(ext);
     Eigen::Map<Eigen::Vector3d> m_t = Eigen::Map<Eigen::Vector3d>(ext + 4);
 
-    ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
+    ceres::Manifold * q_parameterization = new ceres::EigenQuaternionManifold();
     ceres::Problem problem;
 
     problem.AddParameterBlock(ext, 4, q_parameterization);

--- a/src/cam_lid_external2.cpp
+++ b/src/cam_lid_external2.cpp
@@ -1,6 +1,5 @@
 #include <ros/ros.h>
 #include <iostream>
-#include <ceres/ceres.h>
 #include <Eigen/Core>
 #include <fstream>
 #include <pcl/point_cloud.h>
@@ -12,6 +11,7 @@
 
 #include "common.h"
 #include "result_verify.h"
+#include "type.h"
 
 using namespace std;
 
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
     Eigen::Map<Eigen::Quaterniond> m_q = Eigen::Map<Eigen::Quaterniond>(ext);
     Eigen::Map<Eigen::Vector3d> m_t = Eigen::Map<Eigen::Vector3d>(ext + 4);
 
-    ceres::Manifold * q_parameterization = new ceres::EigenQuaternionManifold();
+    ParameterizationPtr q_parameterization = new ParameterizationType();
     ceres::Problem problem;
 
     problem.AddParameterBlock(ext, 4, q_parameterization);

--- a/src/cam_lid_external2.cpp
+++ b/src/cam_lid_external2.cpp
@@ -119,7 +119,7 @@ int main(int argc, char **argv) {
     Eigen::Map<Eigen::Quaterniond> m_q = Eigen::Map<Eigen::Quaterniond>(ext);
     Eigen::Map<Eigen::Vector3d> m_t = Eigen::Map<Eigen::Vector3d>(ext + 4);
 
-    ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
+    ceres::Manifold * q_parameterization = new ceres::EigenQuaternionManifold();
     ceres::Problem problem;
 
     problem.AddParameterBlock(ext, 4, q_parameterization);

--- a/src/color_lidar_display.cpp
+++ b/src/color_lidar_display.cpp
@@ -5,7 +5,6 @@
 
 #include <stdio.h>
 #include <cmath>
-#include <hash_map>
 #include <ctime>
 
 #include <nav_msgs/Odometry.h>
@@ -31,26 +30,26 @@ void loadPointcloudFromROSBag(const string& bag_path);
 typedef pcl::PointXYZRGB PointType;
 vector<livox_ros_driver::CustomMsg> lidar_datas; 
 int threshold_lidar;
-string input_photo_path, input_bag_path, intrinsic_path, extrinsic_path;
+string input_photo_path, input_bag_path, intrinsic_path, extrinsic_path, msg_type;
 
 void loadPointcloudFromROSBag(const string& bag_path) {
     ROS_INFO("Start to load the rosbag %s", bag_path.c_str());
     rosbag::Bag bag;
     try {
         bag.open(bag_path, rosbag::bagmode::Read);
-    } catch (rosbag::BagException e) {
+    } catch (const rosbag::BagException& e) {
         ROS_ERROR_STREAM("LOADING BAG FAILED: " << e.what());
         return;
     }
 
     vector<string> types;
-    types.push_back(string("livox_ros_driver/CustomMsg"));  // message title
+    types.push_back(msg_type);  // message title
     rosbag::View view(bag, rosbag::TypeQuery(types));
 
     for (const rosbag::MessageInstance& m : view) {
         livox_ros_driver::CustomMsg livoxCloud = *(m.instantiate<livox_ros_driver::CustomMsg>()); // message type
         lidar_datas.push_back(livoxCloud);
-        if (lidar_datas.size() > threshold_lidar) {
+        if (lidar_datas.size() > static_cast<size_t>(threshold_lidar)) {
             break;
         }
     }
@@ -108,7 +107,11 @@ void getParameters() {
         exit(1);
     }
     if (!ros::param::get("extrinsic_path", extrinsic_path)) {
-        cout << "Can not get the value o以下程序节点中如果想修改launch文件，需要到src/calibration/launch文件夹中找对应的launch文件。f extrinsic_path" << endl;
+        cout << "Can not get the value of extrinsic_path" << endl;
+        exit(1);
+    }
+    if (!ros::param::get("msg_type", msg_type)) {
+        cout << "Can not get the value of msg_type" << endl;
         exit(1);
     }
 }

--- a/src/pcdTransfer.cpp
+++ b/src/pcdTransfer.cpp
@@ -22,7 +22,7 @@ struct pointData{
 };
 vector<pointData> vector_data;
 livox_ros_driver::CustomMsg livox_cloud;
-string input_bag_path, output_path;
+string input_bag_path, output_path, msg_type;
 int threshold_lidar, data_num;
 
 void loadAndSavePointcloud(int index);
@@ -42,13 +42,13 @@ void loadAndSavePointcloud(int index) {
     rosbag::Bag bag;
     try {
         bag.open(path, rosbag::bagmode::Read);
-    } catch (rosbag::BagException e) {
+    } catch (const rosbag::BagException& e) {
         ROS_ERROR_STREAM("LOADING BAG FAILED: " << e.what());
         return;
     }
 
     vector<string> types;
-    types.push_back(string("livox_ros_driver2/CustomMsg")); 
+    types.push_back(msg_type);
     rosbag::View view(bag, rosbag::TypeQuery(types));
 
     int cloudCount = 0;
@@ -126,6 +126,10 @@ void getParameters() {
     }
     if (!ros::param::get("output_pcd_path", output_path)) {
         cout << "Can not get the value of output_path" << endl;
+        exit(1);
+    }
+    if (!ros::param::get("msg_type", msg_type)) {
+        cout << "Can not get the value of msg_type" << endl;
         exit(1);
     }
     if (!ros::param::get("threshold_lidar", threshold_lidar)) {

--- a/src/projectCloud.cpp
+++ b/src/projectCloud.cpp
@@ -30,26 +30,26 @@ cv::Mat src_img;
 
 vector<livox_ros_driver::CustomMsg> lidar_datas; 
 int threshold_lidar;  // number of cloud point on the photo
-string input_bag_path, input_photo_path, output_path, intrinsic_path, extrinsic_path;
+string input_bag_path, input_photo_path, output_path, intrinsic_path, extrinsic_path, msg_type;
 
 void loadPointcloudFromROSBag(const string& bag_path) {
     ROS_INFO("Start to load the rosbag %s", bag_path.c_str());
     rosbag::Bag bag;
     try {
         bag.open(bag_path, rosbag::bagmode::Read);
-    } catch (rosbag::BagException e) {
+    } catch (const rosbag::BagException& e) {
         ROS_ERROR_STREAM("LOADING BAG FAILED: " << e.what());
         return;
     }
 
     vector<string> types;
-    types.push_back(string("livox_ros_driver/CustomMsg"));  // message title
+    types.push_back(msg_type);  // message title
     rosbag::View view(bag, rosbag::TypeQuery(types));
 
     for (const rosbag::MessageInstance& m : view) {
         livox_ros_driver::CustomMsg livoxCloud = *(m.instantiate<livox_ros_driver::CustomMsg>()); // message type
         lidar_datas.push_back(livoxCloud);
-        if (lidar_datas.size() > (threshold_lidar/24000 + 1)) {
+        if (lidar_datas.size() > static_cast<size_t>(threshold_lidar/24000 + 1)) {
             break;
         }
     }
@@ -121,6 +121,10 @@ void getParameters() {
     }
     if (!ros::param::get("extrinsic_path", extrinsic_path)) {
         cout << "Can not get the value of extrinsic_path" << endl;
+        exit(1);
+    }
+    if (!ros::param::get("msg_type", msg_type)) {
+        cout << "Can not get the value of msg_type" << endl;
         exit(1);
     }
 }

--- a/src/type.h
+++ b/src/type.h
@@ -1,0 +1,16 @@
+#ifndef TYPE_H
+#define TYPE_H
+
+#include <ceres/ceres.h>
+
+// `LocalParameterization` was deprecated in v2.1 and removed in v2.2
+// `Manifold` is the new `LocalParameterization`
+#if CERES_VERSION_MAJOR > 2 || (CERES_VERSION_MAJOR == 2 && CERES_VERSION_MINOR >= 1)
+using ParameterizationType = ceres::EigenQuaternionManifold;
+using ParameterizationPtr = ceres::Manifold*;
+#else
+using ParameterizationType = ceres::EigenQuaternionParameterization;
+using ParameterizationPtr = ceres::LocalParameterization*;
+#endif
+
+#endif // TYPE_H


### PR DESCRIPTION
This commit fixes the following compilation errors:
```
Errors     << camera_lidar_calibration:make /home/user/catkin_ws/logs/camera_lidar_calibration/build.make.000.log                     
In file included from /usr/include/c++/9/backward/hash_map:60,
                 from /home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/color_lidar_display.cpp:8:
/usr/include/c++/9/backward/backward_warning.h:32:2: warning: #warning This file includes at least one deprecated or antiquated header which may be removed without further notice at a future date. Please use a non-deprecated interface with equivalent functionality instead. For a listing of replacement headers and interfaces, consult the file backward_warning.h. To disable this warning use -Wno-deprecated. [-Wcpp]
   32 | #warning \
      |  ^~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/pcdTransfer.cpp: In function ‘void loadAndSavePointcloud(int)’:
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/pcdTransfer.cpp:45:35: warning: catching polymorphic type ‘class rosbag::BagException’ by value [-Wcatch-value=]
   45 |     } catch (rosbag::BagException e) {
      |                                   ^
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external2.cpp: In function ‘int main(int, char**)’:
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external2.cpp:122:12: error: ‘LocalParameterization’ is not a member of ‘ceres’
  122 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |            ^~~~~~~~~~~~~~~~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external2.cpp:122:36: error: ‘q_parameterization’ was not declared in this scope
  122 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |                                    ^~~~~~~~~~~~~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external2.cpp:122:61: error: expected type-specifier
  122 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |                                                             ^~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/projectCloud.cpp: In function ‘void loadPointcloudFromROSBag(const string&)’:
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/projectCloud.cpp:40:35: warning: catching polymorphic type ‘class rosbag::BagException’ by value [-Wcatch-value=]
   40 |     } catch (rosbag::BagException e) {
      |                                   ^
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/projectCloud.cpp:52:32: warning: comparison of integer expressions of different signedness: ‘std::vector<livox_ros_driver::CustomMsg_<std::allocator<void> > >::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
   52 |         if (lidar_datas.size() > (threshold_lidar/24000 + 1)) {
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external1.cpp: In function ‘int main(int, char**)’:
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external1.cpp:123:12: error: ‘LocalParameterization’ is not a member of ‘ceres’
  123 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |            ^~~~~~~~~~~~~~~~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external1.cpp:123:36: error: ‘q_parameterization’ was not declared in this scope
  123 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |                                    ^~~~~~~~~~~~~~~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/cam_lid_external1.cpp:123:61: error: expected type-specifier
  123 |     ceres::LocalParameterization * q_parameterization = new ceres::EigenQuaternionParameterization();
      |                                                             ^~~~~
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/color_lidar_display.cpp: In function ‘void loadPointcloudFromROSBag(const string&)’:
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/color_lidar_display.cpp:41:35: warning: catching polymorphic type ‘class rosbag::BagException’ by value [-Wcatch-value=]
   41 |     } catch (rosbag::BagException e) {
      |                                   ^
/home/user/catkin_ws/src/livox_camera_lidar_calibration_d2/src/color_lidar_display.cpp:53:32: warning: comparison of integer expressions of different signedness: ‘std::vector<livox_ros_driver::CustomMsg_<std::allocator<void> > >::size_type’ {aka ‘long unsigned int’} and ‘int’ [-Wsign-compare]
   53 |         if (lidar_datas.size() > threshold_lidar) {
      |             ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~
make[2]: *** [CMakeFiles/getExt2.dir/build.make:63: CMakeFiles/getExt2.dir/src/cam_lid_external2.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:257: CMakeFiles/getExt2.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make[2]: *** [CMakeFiles/getExt1.dir/build.make:63: CMakeFiles/getExt1.dir/src/cam_lid_external1.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:2525: CMakeFiles/getExt1.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
cd /home/user/catkin_ws/build/camera_lidar_calibration; catkin build --get-env camera_lidar_calibration | catkin env -si  /usr/bin/make --jobserver-auth=3,4; cd -

...................................................................................................................................
Failed     << camera_lidar_calibration:make           [ Exited with code 2 ]                                                       
Failed    <<< camera_lidar_calibration                [ 22.1 seconds ]                                                             
[build] Summary: 1 of 2 packages succeeded.                                                                                        
[build]   Ignored:   None.                                                                                                         
[build]   Warnings:  1 packages succeeded with warnings.                                                                           
[build]   Abandoned: None.                                                                                                         
[build]   Failed:    1 packages failed.                                                                                            
[build] Runtime: 23.2 seconds total.                                                                                               
[build] Note: Workspace packages have changed, please re-source setup files to use them.
```
`Manifold` is the new `LocalParameterization`. `Manifold` was introduced in version 2.1.0, and `LocalParameterization` was removed in version 2.2.0. See http://ceres-solver.org/version_history.html#backward-incompatible-api-changes